### PR TITLE
[Hotfix] Registro manual do contador colorido

### DIFF
--- a/src/pages/AddContador.js
+++ b/src/pages/AddContador.js
@@ -99,7 +99,7 @@ const AddContador = () => {
       setSelectedEquipamentoId(equipamento.id);
       const response = await getPadroes();
       if (response.type === 'success' && response.data) {
-        const padrao = response.data.find(p => p.modelo === equipamento.modeloId);
+        const padrao = response.data.find(p => p.id === Number(equipamento.modeloId));
         if (padrao) {
           setIsColorido(padrao.colorido);
         }

--- a/src/pages/AddContador.js
+++ b/src/pages/AddContador.js
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import '../style/pages/addcontador.css';
 import Navbar from '../components/navbar/Navbar';
 import { getPrinters, getLocalizacao, addContadores } from "../services/printerService";
-import { getPadroes } from "../services/patternService";
+import { getPadrao } from "../services/patternService";
 import { toast } from "react-toastify";
 import SelectContainer from '../components/containers/SelectContainer';
 import DateContainer from '../components/containers/DateContainer';
@@ -97,9 +97,11 @@ const AddContador = () => {
 
     if (equipamento) {
       setSelectedEquipamentoId(equipamento.id);
-      const response = await getPadroes();
+
+      const response = await getPadrao(Number(equipamento.modeloId));
+
       if (response.type === 'success' && response.data) {
-        const padrao = response.data.find(p => p.id === Number(equipamento.modeloId));
+        const padrao = response.data;
         if (padrao) {
           setIsColorido(padrao.colorido);
         }

--- a/src/services/patternService.js
+++ b/src/services/patternService.js
@@ -4,9 +4,9 @@ export async function getPadrao(id) {
   try {
     const response = await api.get(`/printer/padrao/${id}`);
     if (response.status !== 200) {
-      return { type: 'error' };
+      return { type: 'error', data: response.data };
     }
-    return { type: 'success' };
+    return { type: 'success', data: response.data };
   } catch (error) {
     return { type: 'error', error };
   }

--- a/src/tests/pages/AddContador.test.js
+++ b/src/tests/pages/AddContador.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import AddContador from "../../pages/AddContador";
-import { getPadroes } from "../../services/patternService";
+import { getPadrao } from "../../services/patternService";
 import {
   getPrinters,
   addContadores,
@@ -33,8 +33,8 @@ describe("AddContador", () => {
       ],
     });
 
-    getPadroes.mockResolvedValue({
-      data: [{ marca: "Marca 1", modelo: "Modelo 1", colorido: true }],
+    getPadrao.mockResolvedValue({
+      data: { marca: "Marca 1", modelo: "Modelo 1", colorido: true },
     });
 
     getPrinters.mockResolvedValue({


### PR DESCRIPTION
Refs: #79

## Qual o tipo do PR?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Otimização
- [ ] Documentação

## Descrição

Ao tentar registrar manualmente os contadores de uma impressora colorida, o campo "contador colorido" aparecia indisponível, e agora com a mudança a filtragem do padrão para verificar se é colorido ou não esta sendo feita pelo id do padrao respeitando a nova logica.

## Issues relacionadas

- closes #79 

## Testes adicionados ou atualizados?

- [ ] Sim;
- [x] Não, porque: **Ja havia testes o suficiente**;
- [ ] Preciso de ajuda para implementar os testes;